### PR TITLE
Update Makefile.fenster to make Doom example compile on Windows

### DIFF
--- a/examples/doom-c/Makefile.fenster
+++ b/examples/doom-c/Makefile.fenster
@@ -1,13 +1,13 @@
 CFLAGS+=-Wall -DNORMALUNIX -DLINUX -DSNDSERV -D_DEFAULT_SOURCE
-LIBS+=-lm -lc
+LIBS+=-lm
 ifeq ($(OS),Windows_NT)
 	LIBS+= -lgdi32
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
-		LIBS+=-framework Cocoa
+		LIBS+=-lc -framework Cocoa
 	else
-		LIBS+=-lX11
+		LIBS+=-lc -lX11
 	endif
 endif
 


### PR DESCRIPTION
Removed -lc switch from Windows branch of Makefile